### PR TITLE
'output' module in librosa is deprecated now

### DIFF
--- a/audio_operation.py
+++ b/audio_operation.py
@@ -26,7 +26,8 @@ def read_wav(path, sr, duration=None, mono=True):
 
 
 def save_wav(path, wav, sr):
-    librosa.output.write_wav(path=path, y=wav, sr=sr)
+    import soundfile as sf    
+    sf.write(path, wav, sr)
     pass
 
 


### PR DESCRIPTION
see https://stackoverflow.com/questions/63997969/attributeerror-module-librosa-has-no-attribute-output for detail.
'output' was supported in librosa version.0.6.x, but now in ver 0.8.x it is deprecated and unable to use.